### PR TITLE
Add Python 3.4 environment to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     lint,
+    py34-django{20,21,22},
     py35-django{20,21,22},
     py36-django{20,21,22},
     py37-django{20,21,22}


### PR DESCRIPTION
This PR adds a python 3.4 testing environment to tox