### PR TITLE
Fix get_or_create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.2.0 (UNRELEASED)
+------------------
+* Adjust Url.objects.get_or_create() to return a tuple
+
 0.1.0 (2019-10-07)
 ------------------
 * Initial Release

--- a/shortener/manager.py
+++ b/shortener/manager.py
@@ -6,7 +6,7 @@ from django.db import models
 class UrlManager(models.Manager):
     def get_or_create(self, long_url):
         if self.filter(long_url=long_url).exists():  # If a shortened URL already exists, don't make a duplicate.
-            return self.get(long_url=long_url)
+            return self.get(long_url=long_url), False
 
         try:
             hashed = hashlib.sha3_256(long_url.encode('utf-8')).hexdigest()
@@ -19,4 +19,4 @@ class UrlManager(models.Manager):
 
         url = self.create(short_id=hashed[:length], long_url=long_url)
         url.save()
-        return url
+        return url, True

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -10,15 +10,18 @@ class UrlTestCase(TestCase):
         self.redirect = 'https://pennlabs.org'
 
     def test_exists(self):
-        url = Url.objects.get_or_create(long_url=self.redirect)
+        url, created1 = Url.objects.get_or_create(long_url=self.redirect)
         self.assertEqual(len(Url.objects.all()), 1)
-        Url.objects.get_or_create(long_url=self.redirect)
+        self.assertTrue(created1)
+        _, created2 = Url.objects.get_or_create(long_url=self.redirect)
+        self.assertFalse(created2)
         self.assertEqual(len(Url.objects.all()), 1)
         self.assertEqual(Url.objects.all()[0], url)
 
     def test_no_exists(self):
         self.assertEqual(len(Url.objects.all()), 0)
-        url = Url.objects.get_or_create(long_url=self.redirect)
+        url, created = Url.objects.get_or_create(long_url=self.redirect)
+        self.assertTrue(created)
         self.assertEqual(len(Url.objects.all()), 1)
         self.assertEqual(Url.objects.all()[0], url)
 
@@ -28,7 +31,9 @@ class UrlTestCase(TestCase):
             mock_hash.sha3_256.return_value.hexdigest.return_value = 'abcdef'
         except AttributeError:
             mock_hash.sha256.return_value.hexdigest.return_value = 'abcdef'
-        url1 = Url.objects.get_or_create(long_url='url1')
-        url2 = Url.objects.get_or_create(long_url='url2')
+        url1, created1 = Url.objects.get_or_create(long_url='url1')
+        url2, created2 = Url.objects.get_or_create(long_url='url2')
         self.assertEqual(url1.short_id, 'abcde')
+        self.assertTrue(created1)
         self.assertEqual(url2.short_id, 'abcdef')
+        self.assertTrue(created2)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ from shortener.models import Url
 
 class UrlTestCase(TestCase):
     def setUp(self):
-        self.url = Url.objects.get_or_create(long_url='https://pennlabs.org')
+        self.url, _ = Url.objects.get_or_create(long_url='https://pennlabs.org')
 
     def test_str(self):
         self.assertEqual(str(self.url), '{} -- {}'.format(self.url.long_url, self.url.short_id))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,7 +9,7 @@ from shortener.models import Url
 class RedirectViewTestCase(TestCase):
     def setUp(self):
         self.redirect = 'https://pennlabs.org'
-        self.url = Url.objects.get_or_create(long_url=self.redirect)
+        self.url, _ = Url.objects.get_or_create(long_url=self.redirect)
 
     def test_exists(self):
         try:


### PR DESCRIPTION
This PR fixes the implementation of `get_or_create` which is supposed to return a tuple of the object and a boolean stating if a new object was created.